### PR TITLE
update demo for accessibility testing

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="en">
 <meta charset="utf-8">
 <title>Demo for &lt;std-switch></title>
 <script type="module" src="src/switch.mjs"></script>
@@ -46,7 +47,7 @@ try {
   $('#focus-visible-support').textContent = '\u2705';
 } catch (e) {}
 </script>
-    
+
 <h2><code>&lt;std-switch></code></h2>
 
 <div class=container>
@@ -104,3 +105,4 @@ document.addEventListener('input', logEvent);
 document.addEventListener('change', logEvent);
 document.querySelector('#platform-message').innerHTML = `navigator.platform: <var>${navigator.platform}</var>`;
 </script>
+</html>

--- a/src/switch.mjs
+++ b/src/switch.mjs
@@ -503,8 +503,8 @@ export class StdSwitchElement extends HTMLElement {
 
     if (!this.hasAttribute('tabindex'))
       this.setAttribute('tabindex', '0');
-    if (!this.hasAttribute('aria-role'))
-      this.setAttribute('aria-role', 'switch');
+    if (!this.hasAttribute('role'))
+      this.setAttribute('role', 'switch');
     this.setAttribute('aria-checked', this.on ? 'true' : 'false');
   }
 


### PR DESCRIPTION
Related to @aardrian's comments in issue #7, the PR:

* Adds `html lang=“en”` to the demo file to help with AT testing.
* Changes the incorrect `aria-role` attribute to `role`

per @domenic's comment of:
>In general the idea is that this should be like a built-in HTML control in all ways possible

this PR does not include any updates for exposing the switch as disabled with `aria-disabled`.  That can be done in a separate PR if needed.

Thank you